### PR TITLE
Fix: Correct visual positioning of black piano keys

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -298,16 +298,16 @@ body::before {
 }
 
 /* Black key positioning relative to the start of the white keys container */
-.black-key[data-position="0"]  { left: calc(var(--key-width-desktop) * 1 - var(--black-key-width-desktop) / 2 - 1px); } /* C#3 (between C3-D3) */
-.black-key[data-position="1"]  { left: calc(var(--key-width-desktop) * 2 - var(--black-key-width-desktop) / 2 - 1px); } /* D#3 */
-.black-key[data-position="3"]  { left: calc(var(--key-width-desktop) * 4 - var(--black-key-width-desktop) / 2 - 1px); } /* F#3 */
-.black-key[data-position="4"]  { left: calc(var(--key-width-desktop) * 5 - var(--black-key-width-desktop) / 2 - 1px); } /* G#3 */
-.black-key[data-position="5"]  { left: calc(var(--key-width-desktop) * 6 - var(--black-key-width-desktop) / 2 - 1px); } /* A#3 */
-.black-key[data-position="7"]  { left: calc(var(--key-width-desktop) * 8 - var(--black-key-width-desktop) / 2 - 1px); } /* C#4 */
-.black-key[data-position="8"]  { left: calc(var(--key-width-desktop) * 9 - var(--black-key-width-desktop) / 2 - 1px); } /* D#4 */
-.black-key[data-position="10"] { left: calc(var(--key-width-desktop) * 11 - var(--black-key-width-desktop) / 2 - 1px); } /* F#4 */
-.black-key[data-position="11"] { left: calc(var(--key-width-desktop) * 12 - var(--black-key-width-desktop) / 2 - 1px); } /* G#4 */
-.black-key[data-position="12"] { left: calc(var(--key-width-desktop) * 13 - var(--black-key-width-desktop) / 2 - 1px); } /* A#4 */
+.black-key[data-position="0"]  { left: calc(var(--key-width-desktop) * 1 - var(--black-key-width-desktop) * 0.75 - 1px); } /* C#3 (between C3-D3) */
+.black-key[data-position="1"]  { left: calc(var(--key-width-desktop) * 2 - var(--black-key-width-desktop) * 0.75 - 1px); } /* D#3 */
+.black-key[data-position="3"]  { left: calc(var(--key-width-desktop) * 4 - var(--black-key-width-desktop) * 0.75 - 1px); } /* F#3 */
+.black-key[data-position="4"]  { left: calc(var(--key-width-desktop) * 5 - var(--black-key-width-desktop) * 0.75 - 1px); } /* G#3 */
+.black-key[data-position="5"]  { left: calc(var(--key-width-desktop) * 6 - var(--black-key-width-desktop) * 0.75 - 1px); } /* A#3 */
+.black-key[data-position="7"]  { left: calc(var(--key-width-desktop) * 8 - var(--black-key-width-desktop) * 0.75 - 1px); } /* C#4 */
+.black-key[data-position="8"]  { left: calc(var(--key-width-desktop) * 9 - var(--black-key-width-desktop) * 0.75 - 1px); } /* D#4 */
+.black-key[data-position="10"] { left: calc(var(--key-width-desktop) * 11 - var(--black-key-width-desktop) * 0.75 - 1px); } /* F#4 */
+.black-key[data-position="11"] { left: calc(var(--key-width-desktop) * 12 - var(--black-key-width-desktop) * 0.75 - 1px); } /* G#4 */
+.black-key[data-position="12"] { left: calc(var(--key-width-desktop) * 13 - var(--black-key-width-desktop) * 0.75 - 1px); } /* A#4 */
 
 
 .key-label {
@@ -528,16 +528,16 @@ body::before {
     .computer-key-hint { font-size: 0.6em; top: 3px; }
 
     /* Recalculate black key positions for mobile key widths */
-    .black-key[data-position="0"]  { left: calc(var(--key-width-mobile) * 1 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="1"]  { left: calc(var(--key-width-mobile) * 2 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="3"]  { left: calc(var(--key-width-mobile) * 4 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="4"]  { left: calc(var(--key-width-mobile) * 5 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="5"]  { left: calc(var(--key-width-mobile) * 6 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="7"]  { left: calc(var(--key-width-mobile) * 8 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="8"]  { left: calc(var(--key-width-mobile) * 9 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="10"] { left: calc(var(--key-width-mobile) * 11 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="11"] { left: calc(var(--key-width-mobile) * 12 - var(--black-key-width-mobile) / 2 - 0.5px); }
-    .black-key[data-position="12"] { left: calc(var(--key-width-mobile) * 13 - var(--black-key-width-mobile) / 2 - 0.5px); }
+    .black-key[data-position="0"]  { left: calc(var(--key-width-mobile) * 1 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="1"]  { left: calc(var(--key-width-mobile) * 2 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="3"]  { left: calc(var(--key-width-mobile) * 4 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="4"]  { left: calc(var(--key-width-mobile) * 5 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="5"]  { left: calc(var(--key-width-mobile) * 6 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="7"]  { left: calc(var(--key-width-mobile) * 8 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="8"]  { left: calc(var(--key-width-mobile) * 9 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="10"] { left: calc(var(--key-width-mobile) * 11 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="11"] { left: calc(var(--key-width-mobile) * 12 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
+    .black-key[data-position="12"] { left: calc(var(--key-width-mobile) * 13 - var(--black-key-width-mobile) * 0.75 - 0.5px); }
 
     .btn { padding: 10px 18px; font-size: 0.8em; }
     .instruction-group h3 { font-size: 0.9em; }


### PR DESCRIPTION
The black keys on the virtual keyboard were previously centered in the gaps between white keys. This does not accurately represent the layout of a real piano keyboard, where black keys are positioned to the right of their corresponding white key (e.g., C# is to the right of C).

This commit adjusts the CSS for black key positioning. The `left` offset calculation was changed to shift black keys further to the left, making them overlap the right side of their associated white key. This was achieved by changing the offset from 50% of the black key's width to 75% of its width, relative to the edge of the preceding white key block.

The visual result is a keyboard that more accurately reflects the standard piano key layout.